### PR TITLE
Envío de Mensajes a Consumidores - Logica de Reintentos & Refactor

### DIFF
--- a/lib/client/consumer.ex
+++ b/lib/client/consumer.ex
@@ -12,7 +12,7 @@ defmodule Consumer do
 
   def handle_cast({:send_message, message, consumer_pid, queue_name}, state) do
     Logger.info "The consumer #{inspect consumer_pid} received the message: #{message.payload} from queue #{queue_name}"
-    :timer.sleep(:timer.seconds(100)) # Este sleep esta bueno para que el consumer tarde un tiempo en responder el ack, y poder ver el estado de la cola en el medio
+    # :timer.sleep(:timer.seconds(5)) # Este sleep esta bueno para que el consumer tarde un tiempo en responder el ack, y poder ver el estado de la cola en el medio
     Queue.cast(queue_name, {:send_ack, message, consumer_pid})
     { :noreply, state }
   end

--- a/lib/client/consumer.ex
+++ b/lib/client/consumer.ex
@@ -12,7 +12,7 @@ defmodule Consumer do
 
   def handle_cast({:send_message, message, consumer_pid, queue_name}, state) do
     Logger.info "The consumer #{inspect consumer_pid} received the message: #{message.payload} from queue #{queue_name}"
-    # :timer.sleep(:timer.seconds(20)) # Este sleep esta bueno para que el consumer tarde un tiempo en responder el ack, y poder ver el estado de la cola en el medio
+    :timer.sleep(:timer.seconds(100)) # Este sleep esta bueno para que el consumer tarde un tiempo en responder el ack, y poder ver el estado de la cola en el medio
     Queue.cast(queue_name, {:send_ack, message, consumer_pid})
     { :noreply, state }
   end

--- a/lib/model/primary_queue.ex
+++ b/lib/model/primary_queue.ex
@@ -25,44 +25,44 @@ defmodule PrimaryQueue do
 
       if state.work_mode == :publish_subscribe, do: Queue.cast(state.name, {:send_to_subscribers, new_message})
 
-      new_element = %{message: new_message, consumers_that_did_not_ack: [], number_of_attempts: 0}
-      { :reply, OK.success(:message_queued), Map.put(state, :elements, [new_element|state.elements]) }
+      { :reply, OK.success(:message_queued), add_new_element(state, new_message) }
     end
   end
 
   def handle_call({:subscribe, pid}, _from, state) do
-    if Enum.member?(state.subscribers, pid) do
+    if is_subscriber?(pid, state) do
       { :reply, :already_subscribed, state }
     else
       send_to_replica(state.name, { :subscribe, pid })
 
-      { :reply, :subscribed, Map.put(state, :subscribers, [pid|state.subscribers]) }
+      { :reply, :subscribed, add_subscriber(state, pid) }
     end
   end
 
   def handle_call({:unsubscribe, pid}, _from, state) do
-    unless Enum.member?(state.subscribers, pid) do
+    unless is_subscriber?(pid, state) do
       { :reply, :not_subscribed, state }
     else
       send_to_replica(state.name, { :unsubscribe, pid })
 
-      { :reply, :unsubscribed, Map.put(state, :subscribers, List.delete(state.subscribers, pid)) }
+      { :reply, :unsubscribed, remove_subscriber(state, pid) }
     end
   end
 
   def handle_info({:message_attempt_timeout, message}, state) do
-    Logger.info("Voy a reintentar el envio del mensajeeee")
     queue_name = state.name
 
     element = get_element_by_message(state, message)
     unless element == nil or Enum.empty?(element.consumers_that_did_not_ack) do
       if element.number_of_attempts == 5 do
-        Logger.error "discarding message after sending it 5 times"
+        Logger.error "Discarding message #{message.payload} after sending it 5 times. Consumers that didn't answer: #{inspect element.consumers_that_did_not_ack}"
         Queue.cast(state.name, {:delete, element})
         {:noreply, state}
       else
         new_state = update_specific_element(state, message, &(increase_number_of_attempts(&1)))
+        Logger.info "Retrying send message #{message.payload} to consumers: #{inspect element.consumers_that_did_not_ack}. Attempt Nr. #{element.number_of_attempts + 1}"
         send_message_to(message, element.consumers_that_did_not_ack, queue_name)
+        send_to_replica(state.name, {:message_attempt_timeout, message})
         {:noreply, new_state}
       end
     else
@@ -71,13 +71,13 @@ defmodule PrimaryQueue do
   end
 
   def handle_cast({:send_ack, message, consumer_pid}, state) do
-    Logger.info "Me llego un ack de #{inspect consumer_pid}"
-    # ver que pasa si un consumer contesta 2 veces
     new_state = update_specific_element(state, message, &(update_consumers_that_did_not_ack(&1, consumer_pid)))
 
     element = get_element_by_message(new_state, message)
     unless element == nil do
+      Logger.info "Got an ACK of message #{message.payload}, from consumer: #{inspect consumer_pid}"
       if Enum.empty?(element.consumers_that_did_not_ack) do
+        Logger.info "Got all ACKs of message #{message.payload}"
         Queue.cast(state.name, {:delete, element})
       end
 
@@ -87,22 +87,26 @@ defmodule PrimaryQueue do
     { :noreply, new_state }
   end
 
-  def handle_cast({:delete, elem}, state) do
-    send_to_replica(state.name, {:delete, elem})
+  def handle_cast({:delete, element}, state) do
+    send_to_replica(state.name, {:delete, element})
 
-    { :noreply, Map.put(state, :elements, List.delete(state.elements, elem)) }
+    { :noreply, delete_element(state, element) }
   end
 
   def handle_cast({:send_to_subscribers, message}, state) do
     queue_name = state.name
     all_subscribers = state.subscribers
     if Enum.empty?(all_subscribers) do
-      Logger.warning("The queue #{queue_name} has not subscribers to send the message")
+      Logger.warning "The queue #{queue_name} has not subscribers to send the message #{message.payload}"
       { :noreply, state }
     else
       send_message_to(message, all_subscribers, queue_name)
       { :noreply, add_receivers_to_state_message(state, all_subscribers, message) }
     end
+  end
+
+  defp is_subscriber?(pid, state) do
+    Enum.member?(state.subscribers, pid)
   end
 
   defp send_message_to(message, subscribers, queue_name) do
@@ -117,33 +121,14 @@ defmodule PrimaryQueue do
     update_specific_element(state, message, &(init_element(&1, subscribers)))
   end
 
-  defp init_element(element, subscribers) do
-    element
-      |> Map.put(:consumers_that_did_not_ack, subscribers)
-      |> increase_number_of_attempts
-  end
-
   defp send_to_replica(queue_name, request) do
     Queue.replica_name(queue_name)
       |> Queue.cast(request)
   end
 
   defp schedule_retry_call(message) do
-    Logger.info("Scheduling a retry call")
     Process.send_after(self(), {:message_attempt_timeout, message}, 4000)
   end
-
-  defp update_specific_element(state, message, update_element) do
-    Map.put(state, :elements, Enum.map(state.elements, fn element ->
-      if element.message == message do update_element.(element) else element end
-    end))
-  end
-
-  defp update_consumers_that_did_not_ack(element, consumer_pid) do
-    Map.put(element, :consumers_that_did_not_ack, List.delete(element.consumers_that_did_not_ack, consumer_pid))
-  end
-
-  defp increase_number_of_attempts(element), do: Map.put(element, :number_of_attempts, element.number_of_attempts + 1)
 
   defp get_element_by_message(state, message), do: Enum.find(state.elements, &(&1.message == message))
 end

--- a/lib/model/primary_queue.ex
+++ b/lib/model/primary_queue.ex
@@ -118,7 +118,7 @@ defmodule PrimaryQueue do
 
   defp add_receivers_to_state_message(state, subscribers, message) do
     send_to_replica(state.name, { :add_receivers_to_state_message, subscribers, message })
-    update_specific_element(state, message, &(init_element(&1, subscribers)))
+    update_specific_element(state, message, &(init_sent_element_props(&1, subscribers)))
   end
 
   defp send_to_replica(queue_name, request) do

--- a/lib/model/queue.ex
+++ b/lib/model/queue.ex
@@ -63,7 +63,7 @@ defmodule Queue do
         Map.put(element, :consumers_that_did_not_ack, List.delete(element.consumers_that_did_not_ack, consumer_pid))
       end
 
-      defp init_element(element, subscribers) do
+      defp init_sent_element_props(element, subscribers) do
         element
           |> Map.put(:consumers_that_did_not_ack, subscribers)
           |> increase_number_of_attempts

--- a/lib/model/queue.ex
+++ b/lib/model/queue.ex
@@ -35,6 +35,41 @@ defmodule Queue do
       def handle_call(:get, _from, state) do
         { :reply, state, state }
       end
+
+      defp add_new_element(state, new_message) do
+        new_element = %{message: new_message, consumers_that_did_not_ack: [], number_of_attempts: 0}
+        Map.put(state, :elements, [new_element|state.elements])
+      end
+
+      defp delete_element(state, element) do
+        Map.put(state, :elements, List.delete(state.elements, element))
+      end
+
+      defp update_specific_element(state, message, update_element) do
+        Map.put(state, :elements, Enum.map(state.elements, fn element ->
+          if element.message == message do update_element.(element) else element end
+        end))
+      end
+
+      defp add_subscriber(state, subscriber) do
+        Map.put(state, :subscribers, [subscriber|state.subscribers])
+      end
+
+      defp remove_subscriber(state, subscriber) do
+        Map.put(state, :subscribers, List.delete(state.subscribers, subscriber))
+      end
+
+      defp update_consumers_that_did_not_ack(element, consumer_pid) do
+        Map.put(element, :consumers_that_did_not_ack, List.delete(element.consumers_that_did_not_ack, consumer_pid))
+      end
+
+      defp init_element(element, subscribers) do
+        element
+          |> Map.put(:consumers_that_did_not_ack, subscribers)
+          |> increase_number_of_attempts
+      end
+
+      defp increase_number_of_attempts(element), do: Map.put(element, :number_of_attempts, element.number_of_attempts + 1)
     end
   end
 

--- a/lib/model/replica_queue.ex
+++ b/lib/model/replica_queue.ex
@@ -15,7 +15,7 @@ defmodule ReplicaQueue do
   end
 
   def handle_cast({:push, message}, state) do
-    { :noreply, Map.put(state, :elements, [%{message: message, consumers_that_did_not_ack: []}|state.elements]) }
+    { :noreply, Map.put(state, :elements, [%{message: message, consumers_that_did_not_ack: [], number_of_attempts: 0}|state.elements]) }
   end
 
   def handle_cast({:delete, element}, state) do
@@ -34,6 +34,7 @@ defmodule ReplicaQueue do
     { :noreply, Map.put(state, :elements, Enum.map(state.elements, fn element ->
       if element.message == message do
         Map.put(element, :consumers_that_did_not_ack, subscribers)
+        Map.put(element, :number_of_attempts, 1)
       else
         element
       end

--- a/lib/model/replica_queue.ex
+++ b/lib/model/replica_queue.ex
@@ -31,7 +31,7 @@ defmodule ReplicaQueue do
   end
 
   def handle_cast({:add_receivers_to_state_message, subscribers, message}, state) do
-    { :noreply, update_specific_element(state, message, &(init_element(&1, subscribers))) }
+    { :noreply, update_specific_element(state, message, &(init_sent_element_props(&1, subscribers))) }
   end
 
   def handle_cast({:send_ack, message, consumer_pid}, state) do


### PR DESCRIPTION
## Que incluye este PR:

- Un refactor para que no se repita codigo en la `PrimaryQueue` y la `ReplicaQueue`
- Un refactor para delegar en funciones mas chicas para tener mas expresividad y funciones reutilizables
- La logica de reintentos del envio de mensajes a consumidores (5 intentos por mensaje con 4 segundos entre intento - _esto a posteriori podria ser configurable mediante un archivo de configuracion o al crear la cola_). Se envia solamente el mensaje de nuevo a los consumidores que no hayan respondido

_Los refactors la verdad es que hicieron el codigo 1000 veces mas legible_

## Probando ... 1, 2, 3

Creando una cola con modo de trabajo Publicar Suscribir:
- Si al enviar un mensaje, los consumidores responden ACK, funciona igual que antes
- Si al enviar un mensaje, los consumidores tardan en enviar ACK, pero eventualmente lo hacen, se ve algo asi:
![image](https://user-images.githubusercontent.com/42644816/144687733-39b39dcf-c915-4c7c-8cf7-e4cf7a1873d2.png)
Y se elimina el mensaje de la cola porque ya se recibieron todos los ACKs
- Si al enviar un mensaje, los consumidores no responden nunca, se ve algo asi:
![image](https://user-images.githubusercontent.com/42644816/144687830-e7d5f6c2-5ff7-41a1-9c5d-44c4e8ff1e4f.png)
Y se elimina el mensaje de la cola porque nunca respondieron todos
