### PR TITLE
Desuscribir a un suscriptor si no contesta

### DIFF
--- a/lib/model/queue.ex
+++ b/lib/model/queue.ex
@@ -55,12 +55,12 @@ defmodule Queue do
         Map.put(state, :subscribers, [subscriber|state.subscribers])
       end
 
-      defp remove_subscriber(state, subscriber) do
-        Map.put(state, :subscribers, List.delete(state.subscribers, subscriber))
+      defp remove_subscribers(state, subscribers) do
+        Map.put(state, :subscribers, state.subscribers -- subscribers)
       end
 
-      defp update_consumers_that_did_not_ack(element, consumer_pid) do
-        Map.put(element, :consumers_that_did_not_ack, List.delete(element.consumers_that_did_not_ack, consumer_pid))
+      defp update_consumers_that_did_not_ack(element, consumers) do
+        Map.put(element, :consumers_that_did_not_ack, element.consumers_that_did_not_ack -- consumers)
       end
 
       defp init_sent_element_props(element, subscribers) do
@@ -70,6 +70,17 @@ defmodule Queue do
       end
 
       defp increase_number_of_attempts(element), do: Map.put(element, :number_of_attempts, element.number_of_attempts + 1)
+
+      defp delete_subscribers(state, subscribers_to_delete) do
+        new_state = remove_subscribers(state, subscribers_to_delete)
+        delete_subscribers_from_all_elements(new_state, subscribers_to_delete)
+      end
+
+      defp delete_subscribers_from_all_elements(state, subscribers_to_delete) do
+        Map.put(state, :elements, Enum.map(state.elements, fn element ->
+          update_consumers_that_did_not_ack(element, subscribers_to_delete)
+        end))
+      end
     end
   end
 

--- a/lib/model/queue.ex
+++ b/lib/model/queue.ex
@@ -59,7 +59,7 @@ defmodule Queue do
       end
 
       defp add_subscriber(state, subscriber) do
-        Map.put(state, :subscribers, state.subscribers ++ [subscriber] )
+        Map.put(state, :subscribers, state.subscribers ++ [subscriber])
       end
 
       defp remove_subscribers(state, subscribers) do
@@ -72,8 +72,8 @@ defmodule Queue do
 
       defp init_sent_element_props(element, subscribers) do
         element
-        |> Map.put(:consumers_that_did_not_ack, subscribers)
-        |> increase_number_of_attempts
+          |> Map.put(:consumers_that_did_not_ack, subscribers)
+          |> increase_number_of_attempts
       end
 
       defp increase_number_of_attempts(element), do: Map.put(element, :number_of_attempts, element.number_of_attempts + 1)
@@ -99,16 +99,14 @@ defmodule Queue do
     end
   end
 
-  def via_tuple(queue_name),
-      do: {:via, Horde.Registry, {App.HordeRegistry, queue_name}}
+  def via_tuple(queue_name), do: {:via, Horde.Registry, {App.HordeRegistry, queue_name}}
 
-  def whereis(queue_name),
-      do: GenServer.whereis(via_tuple(queue_name))
+  def whereis(queue_name), do: GenServer.whereis(via_tuple(queue_name))
 
   def merge_queues(queue1, queue2) do
     Enum.concat(queue1, queue2)
-    |> Enum.sort_by(fn msg -> msg.timestamp end, &DateTime.compare(&1, &2) != :lt)
-    |> Enum.dedup
+      |> Enum.sort_by(fn msg -> msg.timestamp end, &DateTime.compare(&1, &2) != :lt)
+      |> Enum.dedup
   end
 
   def create_message(payload) do
@@ -122,16 +120,14 @@ defmodule Queue do
 
   defp replica_sufix, do: "_replica"
 
-  def replica_name(queue_name) when is_atom(queue_name),
-    do: Atom.to_string(queue_name) <> replica_sufix() |> String.to_atom
+  def replica_name(queue_name) when is_atom(queue_name), do: Atom.to_string(queue_name) <> replica_sufix() |> String.to_atom
 
   def primary_name(replica_name) when is_atom(replica_name),
     do: Atom.to_string(replica_name)
         |> String.slice(0..-String.length(replica_sufix())-1)
         |> String.to_atom
 
-  def valid_name?(queue_name),
-    do: not String.ends_with?(Atom.to_string(queue_name), replica_sufix())
+  def valid_name?(queue_name), do: not String.ends_with?(Atom.to_string(queue_name), replica_sufix())
 
   def alive?(name), do: whereis(name) != nil
 
@@ -141,12 +137,12 @@ defmodule Queue do
 
   def cast(queue_name, request) do
     via_tuple(queue_name)
-    |> GenServer.cast(request)
+      |> GenServer.cast(request)
   end
 
   def call(queue_name, request) do
     via_tuple(queue_name)
-    |> GenServer.call(request)
+      |> GenServer.call(request)
   end
 
   def new(queue_name, max_size, work_mode) do

--- a/lib/model/replica_queue.ex
+++ b/lib/model/replica_queue.ex
@@ -35,8 +35,7 @@ defmodule ReplicaQueue do
   end
 
   def handle_cast({:update_next_subscriber_to_send, next_subscriber_to_send}, state) do
-    new_state = update_next_subscriber(state, next_subscriber_to_send)
-    { :noreply, new_state }
+    { :noreply, update_next_subscriber(state, next_subscriber_to_send) }
   end
 
   def handle_cast({:send_ack, message, consumer_pid}, state) do

--- a/lib/model/replica_queue.ex
+++ b/lib/model/replica_queue.ex
@@ -27,7 +27,7 @@ defmodule ReplicaQueue do
   end
 
   def handle_cast({:unsubscribe, pid}, state) do
-    { :noreply, remove_subscriber(state, pid) }
+    { :noreply, remove_subscribers(state, [pid]) }
   end
 
   def handle_cast({:add_receivers_to_state_message, subscribers, message}, state) do
@@ -35,10 +35,14 @@ defmodule ReplicaQueue do
   end
 
   def handle_cast({:send_ack, message, consumer_pid}, state) do
-    { :noreply, update_specific_element(state, message, &(update_consumers_that_did_not_ack(&1, consumer_pid))) }
+    { :noreply, update_specific_element(state, message, &(update_consumers_that_did_not_ack(&1, [consumer_pid]))) }
   end
 
   def handle_cast({:message_attempt_timeout, message}, state) do
     { :noreply, update_specific_element(state, message, &(increase_number_of_attempts(&1))) }
+  end
+
+  def handle_cast({:delete_dead_subscribers, subscribers_to_delete}, state) do
+    { :noreply, delete_subscribers(state, subscribers_to_delete) }
   end
 end


### PR DESCRIPTION
Dado un escenario en el que se tiene como suscriptores de la cola al consumidor `Tom` y al consumidor `Jerry`, y se pushea un mensaje `Holiss` a la cola, por lo tanto se envía a ambos consumidores.

Si `Tom` contesta al toque con un ACK, pero `Jerry` no contesta aún cuando ya le reenviamos el mensaje 5 veces porque se re cayó...

## Como está en `main`:

Eliminamos al mensaje `Holiss` de la cola, pero si posteriormente llegan mas mensajes a la cola, siempre se va a reintentar enviarle el mensaje a `Jerry` 5 veces, y siempre se va a terminar descartando (pero `Jerry` no contesta y no va a contestar nunca)

## Como sería con este PR:

Eliminamos al mensaje `Holiss` de la cola, y desuscribimos a `Jerry` de la cola para evitar el problema mencionado de mensajes nuevos que lleguen a la cola.

Luego, recorremos la lista de mensajes que todavia estén en la cola y tengan a `Jerry` como lista de consumidores que no respondieron, y también lo borramos de esas listas para que no tengan el mismo problema.

Si ademas de ese consumidor tenían algun otro, simplemente seguirán esperando el ACK del consumidor restante.

Si solo tenian a `Jerry`, la lista queda vacia, es decir, no estan esperando mas ACKs de nadie, por lo que borramos tambien a esos mensajes


