### PR TITLE
notify subscribers on queue shutdown

### DIFF
--- a/lib/model/primary_queue.ex
+++ b/lib/model/primary_queue.ex
@@ -107,7 +107,7 @@ defmodule PrimaryQueue do
   def handle_cast({:delete_dead_subscribers, subscribers_to_delete}, state) do
     send_to_replica(state.name, {:delete_dead_subscribers, subscribers_to_delete})
     Enum.each(subscribers_to_delete, fn sub ->
-      UDPServer.send_remove_notification(state.name, "timed out", sub)
+      UDPServer.send_error(state.name, "timed out", sub)
     end)
     { :noreply, delete_subscribers(state, subscribers_to_delete) }
   end
@@ -144,6 +144,15 @@ defmodule PrimaryQueue do
                   |> add_receivers_to_state_message([subscriber_to_send], message)
       {:noreply, new_state}
     end
+  end
+
+
+  def handle_cast(:notify_shutdown, state) do
+    info(state.name, "queue deleted, notifying subscribers")
+    Enum.each(state.subscribers, fn sub ->
+      UDPServer.send_error(state.name, "the queue was deleted", sub)
+    end)
+    {:noreply, state}
   end
 
   defp is_subscriber?(consumer, state) do

--- a/lib/model/queue.ex
+++ b/lib/model/queue.ex
@@ -179,6 +179,7 @@ defmodule Queue do
   def delete(queue_name) do
     OK.for do
       { primary_name, replica_name } <- complete_check(queue_name, &check_alive/1)
+      GenServer.cast(via_tuple(primary_name), :notify_shutdown)
       Horde.DynamicSupervisor.terminate_child(App.HordeSupervisor, whereis(primary_name))
       Horde.DynamicSupervisor.terminate_child(App.HordeSupervisor, whereis(replica_name))
     after


### PR DESCRIPTION
Ahora la cola manda una notificacion a sus suscriptores cuando la borran. Una boludez pero me parece correcto para no dejar a los subs en banda